### PR TITLE
Prepare automated publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build and test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
 
       - name: Cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: release
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  publish_crates_io:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for OIDC token exchange
+    steps:
+      - uses: actions/checkout@v6
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
+      - name: Publish powersync crate
+        run: cargo publish
+        working-directory: powersync
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## 0.0.2
+
+- Configure automated publishing to crates.io.
+
+## 0.0.1
+
+- Initial release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3672,7 +3672,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powersync"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "async-broadcast",
  "async-channel 2.5.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3672,7 +3672,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powersync"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "async-broadcast",
  "async-channel 2.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
 [workspace]
 resolver = "3"
 members = [ "examples/egui_todolist","powersync", "powersync_test_utils"]
+
+[workspace.package]
+repository = "https://github.com/powersync-ja/powersync-native"

--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ _[PowerSync](https://www.powersync.com) is a sync engine for building local-firs
 
 ## PowerSync Native
 
-This repository contains code used to build a PowerSync SDK for native development.
+> [!CAUTION]
+> The PowerSync Rust SDK is currently experimental and in a pre-alpha state.
+> We offer no stability guarantees for this SDK, and can't guarantee continued support for it.
+> If you're interested in using this, please [reach out](https://www.powersync.com/contact)!
 
-PowerSync is available as a Rust crate in `powersync/`. Note that this crate is not currently published to crates.io,
-and that it downloads additional binaries in its `build.rs`. This is something we're looking to address in the future.
-At the moment, we are primarily targeting C++ development with this SDK (although the SDK is implemented in Rust).
+This repository contains code used to build a PowerSync SDK for native development.
+PowerSync is available as a Rust crate in `powersync/`, and on crates.io as the `powersync` crate.
 
 ## Running the examples
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,9 @@
+## Preparing releases
+
+First, bump the version in `powersync/Cargo.toml`. Run a build to ensure it's also updated in `Cargo.lock`.
+Also ensure all changes are described in `CHANGELOG.md`.
+
+Next, open a PR with these changes and wait for it to get approved and merged.
+
+Finally, [create a release](https://github.com/powersync-ja/powersync-native/releases) on GitHub.
+Creating the associated tag will trigger a workflow to publish to crates.io.

--- a/powersync/Cargo.toml
+++ b/powersync/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "powersync"
-version = "0.1.0"
+version = "0.0.1"
+
 edition = "2024"
+license = "Apache-2.0"
+authors = ["JourneyApps"]
+keywords = ["sqlite", "powersync"]
+homepage = "https://powersync.com"
+repository.workspace = true
+readme = "README.md"
 
 [lib]
 crate-type = ["lib"]

--- a/powersync/Cargo.toml
+++ b/powersync/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["sqlite", "powersync"]
 homepage = "https://powersync.com"
 repository.workspace = true
 readme = "README.md"
+description = "Experimental PowerSync SDK for Rust applications."
 
 [lib]
 crate-type = ["lib"]

--- a/powersync/Cargo.toml
+++ b/powersync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "powersync"
-version = "0.0.1"
+version = "0.0.2"
 
 edition = "2024"
 license = "Apache-2.0"
@@ -40,7 +40,7 @@ thiserror = "2.0.16"
 tokio = { version = "1", features = ["time", "rt"], optional = true }
 url = "2.5.7"
 serde_with = "3.15.0"
-powersync_core = { version = "0.4.9", features = ["static"] }
+powersync_core = { version = "=0.4.9", features = ["static"] }
 
 [dev-dependencies]
 async-executor = "1.13.3"

--- a/powersync/README.md
+++ b/powersync/README.md
@@ -6,6 +6,11 @@ _[PowerSync](https://www.powersync.com) is a sync engine for building local-firs
 
 # PowerSync Rust
 
+> [!CAUTION]
+> The PowerSync Rust SDK is currently experimental and in a pre-alpha state.
+> We offer no stability guarantees for this SDK, and can't guarantee continued support for it.
+> If you're interested in using this, please [reach out](https://www.powersync.com/contact)!
+
 ## Setup
 
 PowerSync is implemented over local SQLite databases. The main entrypoint for this library, `PowerSyncDatabase`,

--- a/powersync/src/util/shared_future.rs
+++ b/powersync/src/util/shared_future.rs
@@ -129,9 +129,9 @@ enum SharedFutureEnum {
 
 #[cfg(test)]
 mod test {
-    use std::{cell::RefCell, pin::pin, sync::atomic::AtomicBool, task::Poll};
+    use std::{cell::RefCell, pin::pin, task::Poll};
 
-    use futures_lite::{FutureExt, future};
+    use futures_lite::future;
     use futures_test::task::noop_context;
 
     use crate::util::SharedFuture;

--- a/powersync/tests/sync_test.rs
+++ b/powersync/tests/sync_test.rs
@@ -7,7 +7,7 @@ use powersync::{
 use powersync_test_utils::{
     DatabaseTest,
     mock_sync_service::TestConnector,
-    sync_line::{BucketChecksum, Checkpoint, StreamDescription, SyncLine},
+    sync_line::{Checkpoint, SyncLine},
 };
 use serde_json::json;
 


### PR DESCRIPTION
This adds a warning explaining that the SDK is currently in an experimental state and repares GitHub workflows for automated publishing.

I will try to publish this as 0.0.2 after it is approved.