### PR TITLE
Retry on failed crud uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-## 0.0.6 (unreleased)
+## 0.0.6
 
 - Skip creating `ps_crud` entries when clearing raw tables.
+- Call `upload_data` repeatedly if an upload fails.
+- Add `PowerSyncError::upload_error`, which can be used to convert any error into PowerSync errors for
+  `upload_data` callbacks.
 
 ## 0.0.5
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3084,7 +3084,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powersync"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "async-channel",
  "async-executor",

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To start an example:
 3. Compile and run an example here: `cargo run -p egui_todolist`.
 
 ```yaml
-# Sync-rule docs: https://docs.powersync.com/usage/sync-rules
+# Sync Streams docs: https://docs.powersync.com/sync/streams/overview
 streams:
   lists:
     query: SELECT * FROM lists #WHERE owner_id = auth.user_id()
@@ -32,5 +32,5 @@ streams:
     query: SELECT * FROM todos WHERE list_id = subscription.parameter('list') #AND list_id IN (SELECT id FROM lists WHERE owner_id = auth.user_id())
 
 config:
-  edition: 2
+  edition: 3
 ```

--- a/powersync/Cargo.toml
+++ b/powersync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "powersync"
-version = "0.0.5"
+version = "0.0.6"
 
 edition = "2024"
 license = "Apache-2.0"

--- a/powersync/src/db/internal.rs
+++ b/powersync/src/db/internal.rs
@@ -10,6 +10,7 @@ use crate::{
     util::SharedFuture,
 };
 use event_listener::EventListener;
+use futures_lite::future::yield_now;
 use futures_lite::{FutureExt, Stream, StreamExt, ready};
 use powersync_sqlite_nostd::{Destructor, ResultCode};
 use std::sync::{Mutex, Weak};
@@ -144,8 +145,12 @@ impl InnerPowerSyncState {
             *guard
         };
 
-        if let Some(delay) = delay {
+        if let Some(delay) = delay
+            && delay > Duration::ZERO
+        {
             self.env.timer.delay_once(delay).await
+        } else {
+            yield_now().await
         }
     }
 

--- a/powersync/src/error.rs
+++ b/powersync/src/error.rs
@@ -17,6 +17,15 @@ pub struct PowerSyncError {
 }
 
 impl PowerSyncError {
+    /// Wrap any error as a PowerSync error to indicate an error in a
+    /// [crate::BackendConnector::upload_data] implementation.
+    pub fn upload_error(inner: impl Error + Send + Sync + 'static) -> Self {
+        RawPowerSyncError::UploadError {
+            source: Box::new(inner),
+        }
+        .into()
+    }
+
     pub(crate) fn argument_error(desc: impl Into<Cow<'static, str>>) -> Self {
         RawPowerSyncError::ArgumentError { desc: desc.into() }.into()
     }
@@ -108,6 +117,11 @@ pub(crate) enum RawPowerSyncError {
     InvalidCredentials,
     #[error("Unexpected HTTP status code from PowerSync service: {code}")]
     UnexpectedStatusCode { code: u16 },
+    #[error("Error in upload_data: {source}")]
+    UploadError {
+        #[source]
+        source: Box<dyn Error + Send + Sync>,
+    },
 }
 
 impl From<ResultCode> for PowerSyncError {

--- a/powersync/src/sync/upload.rs
+++ b/powersync/src/sync/upload.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::HashSet, ops::ControlFlow, sync::Arc};
 
 use futures_lite::{
     FutureExt, StreamExt,
@@ -159,55 +159,16 @@ impl UploadActor {
                     Self::state_transition_from_command_while_uploading(&self.commands, &self.db);
 
                 let upload_done = async {
-                    let (result, state) = result.await;
+                    let state = result.await;
+                    self.db
+                        .status
+                        .update(|s| s.set_upload_state(UploadStatus::Idle));
 
-                    match result {
-                        Ok(_) => {
-                            // It's possible that pending CRUD uploads were preventing data from
-                            // syncing. So now that that's completed, notify the download client in
-                            // case it needs to retry.
-                            if let Some(sync) = self.db.sync.upgrade() {
-                                sync.mark_crud_uploads_completed().await;
-                            }
-
-                            // Apart from that, the upload is done and we transition back into the
-                            // ready connected state to start the next iteration when needed.
-                            Some(UploadActorState::Connected(state))
-                        }
-                        Err(e) => {
-                            warn!("CRUD uploads failed, will retry, {e}");
-                            self.db
-                                .status
-                                .update(|s| s.set_upload_state(UploadStatus::Error(e)));
-                            let db = self.db.clone();
-
-                            Some(UploadActorState::WaitingForReconnect {
-                                timeout: async move {
-                                    db.sync_iteration_delay().await;
-                                    state
-                                }
-                                .boxed(),
-                            })
-                        }
-                    }
-                };
-
-                future::race(request, upload_done)
-                    .await
-                    .unwrap_or(old_state)
-            }
-            UploadActorState::WaitingForReconnect { ref mut timeout } => {
-                // Either the timeout expires, in which case we reconnect, or a disconnect is
-                // requested.
-                let request =
-                    Self::state_transition_from_command_while_uploading(&self.commands, &self.db);
-
-                let timeout_expired = async {
-                    let state = timeout.await;
+                    // The upload is done and we transition back into the  ready connected state to start the next iteration when needed.
                     Some(UploadActorState::Connected(state))
                 };
 
-                future::race(request, timeout_expired)
+                future::race(request, upload_done)
                     .await
                     .unwrap_or(old_state)
             }
@@ -223,9 +184,9 @@ impl UploadActor {
                     connector: state.connector.as_ref(),
                     db,
                 };
-                let result = upload.run().await;
+                upload.run().await;
 
-                (result, state)
+                state
             }
             .boxed(),
         }
@@ -235,12 +196,7 @@ impl UploadActor {
 enum UploadActorState {
     Idle,
     Connected(ConnectedUploadActor),
-    RunningUpload {
-        result: Boxed<(Result<(), PowerSyncError>, ConnectedUploadActor)>,
-    },
-    WaitingForReconnect {
-        timeout: Boxed<ConnectedUploadActor>,
-    },
+    RunningUpload { result: Boxed<ConnectedUploadActor> },
     Stopped,
 }
 
@@ -263,31 +219,61 @@ struct CrudUpload<'a> {
 }
 
 impl<'a> CrudUpload<'a> {
-    pub async fn run(&mut self) -> Result<(), PowerSyncError> {
+    pub async fn run(&mut self) {
         let mut last_item_id = None::<i64>;
 
-        while let Some(item) = self.oldest_crud_item_id().await? {
-            if last_item_id == Some(item) {
-                warn!("{}", Self::DUPLICATE_ITEM_WARNING);
-                return Err(PowerSyncError::argument_error(
-                    "Delaying due to previously encountered CRUD item.",
-                ));
+        // Invoke upload method on connector until there are no remaining CRUD items to upload.
+        loop {
+            match self.upload_step(&mut last_item_id).await {
+                Ok(ControlFlow::Break(_)) => break,
+                Ok(ControlFlow::Continue(_)) => continue,
+                Err(e) => {
+                    last_item_id = None;
+                    info!("CRUD uploads failed, will retry, {e}");
+
+                    self.db
+                        .status
+                        .update(|data| data.set_upload_state(UploadStatus::Error(e)));
+                    self.db.sync_iteration_delay().await;
+                }
+            }
+        }
+    }
+
+    async fn upload_step(
+        &mut self,
+        last_item_id: &mut Option<i64>,
+    ) -> Result<ControlFlow<()>, PowerSyncError> {
+        let Some(item) = self.oldest_crud_item_id().await? else {
+            // Uploading is completed, advance write checkpoint.
+            if let Some(advance_target) = self.sequence_for_checkpoint().await? {
+                let write_checkpoint = self.get_write_checkpoint().await?;
+                advance_target.complete(write_checkpoint, &self.db).await?;
             }
 
-            last_item_id = Some(item);
-            self.db
-                .status
-                .update(|data| data.set_upload_state(UploadStatus::Uploading));
-            self.connector.upload_data().await?;
+            // It's possible that pending CRUD uploads were preventing data from  syncing. So now
+            // that that's completed, notify the download client in case it needs to retry.
+            if let Some(sync) = self.db.sync.upgrade() {
+                sync.mark_crud_uploads_completed().await;
+            }
+
+            return Ok(ControlFlow::Break(()));
+        };
+
+        self.db
+            .status
+            .update(|data| data.set_upload_state(UploadStatus::Uploading));
+        if matches!(*last_item_id, Some(x) if x == item) {
+            warn!("{}", Self::DUPLICATE_ITEM_WARNING);
+            return Err(PowerSyncError::argument_error(
+                "Delaying due to previously encountered CRUD item.",
+            ));
         }
 
-        // Uploading is completed, advance write checkpoint.
-        if let Some(advance_target) = self.sequence_for_checkpoint().await? {
-            let write_checkpoint = self.get_write_checkpoint().await?;
-            advance_target.complete(write_checkpoint, &self.db).await?;
-        }
+        *last_item_id = Some(item);
+        self.connector.upload_data().await?;
 
-        Ok(())
+        Ok(ControlFlow::Continue(()))
     }
 
     async fn oldest_crud_item_id(&self) -> Result<Option<i64>, PowerSyncError> {

--- a/powersync/tests/sync_test.rs
+++ b/powersync/tests/sync_test.rs
@@ -420,5 +420,7 @@ fn upload_retry() {
 
         sync.wait_for_status(|s| s.upload_error().is_none() && !s.is_uploading())
             .await;
+
+        assert!(sync.db.next_crud_transaction().await.unwrap().is_none());
     });
 }

--- a/powersync/tests/sync_test.rs
+++ b/powersync/tests/sync_test.rs
@@ -1,15 +1,27 @@
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
 use async_task::Task;
+use async_trait::async_trait;
+use event_listener::Event;
 use futures_lite::{StreamExt, future};
 use powersync::{
-    PowerSyncDatabase, StreamPriority, StreamSubscription, StreamSubscriptionOptions, SyncOptions,
-    SyncStatusData, error::PowerSyncError,
+    BackendConnector, PowerSyncCredentials, PowerSyncDatabase, StreamPriority, StreamSubscription,
+    StreamSubscriptionOptions, SyncOptions, SyncStatusData, error::PowerSyncError,
 };
 use powersync_test_utils::{
     DatabaseTest,
     mock_sync_service::TestConnector,
     sync_line::{Checkpoint, SyncLine},
 };
+use rusqlite::params;
 use serde_json::json;
+use thiserror::Error;
 
 struct SyncStreamTest {
     test: DatabaseTest,
@@ -331,5 +343,82 @@ fn progress_without_priorities() {
 
         request.send_checkpoint_complete(oplog_id, None).await;
         sync.wait_for_status(|s| !s.is_downloading()).await;
+    });
+}
+
+#[test]
+fn upload_retry() {
+    struct FailOnFirstUpload {
+        db: PowerSyncDatabase,
+        counter: Arc<AtomicUsize>,
+        completed_second: Arc<Event>,
+    }
+
+    #[derive(Error, Debug)]
+    #[error("Deliberate failure on first upload")]
+    struct FirstUploadFailure;
+
+    #[async_trait]
+    impl BackendConnector for FailOnFirstUpload {
+        async fn fetch_credentials(&self) -> Result<PowerSyncCredentials, PowerSyncError> {
+            Ok(PowerSyncCredentials {
+                endpoint: "https://rust.unit.test.powersync.com/".to_string(),
+                token: "token".to_string(),
+            })
+        }
+
+        async fn upload_data(&self) -> Result<(), PowerSyncError> {
+            let Some(tx) = self.db.next_crud_transaction().await? else {
+                return Ok(());
+            };
+
+            let old_count = self.counter.fetch_add(1, Ordering::SeqCst);
+            if old_count == 0 {
+                return Err(PowerSyncError::upload_error(FirstUploadFailure));
+            }
+
+            tx.complete().await?;
+            self.completed_second.notify(usize::MAX);
+            Ok(())
+        }
+    }
+
+    let sync = SyncStreamTest::new();
+    let upload_counter = Arc::new(AtomicUsize::default());
+    let event = Arc::new(Event::new());
+    let mut options = SyncOptions::new(FailOnFirstUpload {
+        db: sync.db.clone(),
+        counter: upload_counter.clone(),
+        completed_second: event.clone(),
+    });
+    options.with_retry_delay(Duration::ZERO); // We can't use timers in tests
+    sync.run(sync.db.connect(options));
+
+    sync.run(async {
+        sync.wait_for_status(|s| s.is_connected()).await;
+
+        // Trigger a crud upload.
+        {
+            let writer = sync.db.writer().await.unwrap();
+            writer
+                .execute(
+                    "INSERT INTO users (id, name) VALUES (uuid(), 'local user')",
+                    params![],
+                )
+                .unwrap();
+        }
+
+        // Wait for the second upload to finish.
+        loop {
+            let listener = event.listen();
+            if upload_counter.load(Ordering::SeqCst) == 2 {
+                break;
+            };
+
+            listener.await
+        }
+
+        sync.wait_for_status(|s| s.upload_error().is_none() && !s.is_uploading())
+            .await;
     });
 }


### PR DESCRIPTION
The state machine in upload actors to recover from upload errors was broken (the transition after `WaitingForReconnect` goes to `Connected` which is an idle state, it should transition to `start_upload()` instead).

But we don't really need a separate error state in the state machine at all, we can instead use a single `async` function to retry uploads in a `loop` until there are no more remaining entries or the upload is cancelled. This PR removes the `WaitingForReconnect` state and migrates most of the upload logic from an explicit state machine invocation into `CrudUpload::run`.

AI use: Changes manual, reviewed with Claude Code.

Closes https://github.com/powersync-ja/powersync-native/issues/15.