### PR TITLE
Fix non-Unix database path compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,15 @@ jobs:
 
       - name: Build without rusqlite
         run: cargo build --no-default-features
+
+  windows:
+    name: Check Windows build
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust
+        run: rustup update stable
+
+      - name: Check PowerSync crate
+        run: cargo check -p powersync --all-targets

--- a/powersync/src/db/connection.rs
+++ b/powersync/src/db/connection.rs
@@ -204,7 +204,9 @@ fn path_to_cstring(p: &Path) -> Result<CString, PowerSyncError> {
 
 #[cfg(not(unix))]
 fn path_to_cstring(p: &Path) -> Result<CString, PowerSyncError> {
-    let s = p.to_str().ok_or_else(|| Error::InvalidPath(p.to_owned()))?;
+    let s = p.to_str().ok_or_else(|| RawPowerSyncError::ArgumentError {
+        desc: format!("Invalid path: {p:?}").into(),
+    })?;
     Ok(
         CString::new(s).map_err(|_| RawPowerSyncError::ArgumentError {
             desc: format!("Invalid path: {p:?}").into(),


### PR DESCRIPTION
## What changed

- replace the undeclared `Error::InvalidPath` in the non-Unix path conversion
  with the crate's existing `RawPowerSyncError::ArgumentError`
- add a Windows CI job that checks the `powersync` crate on `windows-latest`

## Root cause

The Windows-only branch was not compiled by the Linux CI job, so the undeclared
type reached `main`. The implementation now mirrors the Unix branch's error
shape, and CI exercises the actual Windows configuration.

Fixes #20.

## Validation

- `rustup run 1.96.0 cargo fmt --all -- --check`
- `rustup run 1.96.0 cargo check -p powersync --target x86_64-pc-windows-msvc`

The cross-target check now completes successfully from macOS; the added Actions
job will also compile on a native Windows runner.
