### PR TITLE
Update core extension to 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.0.7 (unreleased)
+## 0.0.7
 
-- Update PowerSync core extension to version 0.5.1.
+- Update PowerSync core extension to version 0.5.2.
 
 ## 0.0.6
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3084,7 +3084,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powersync"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -3117,9 +3117,9 @@ dependencies = [
 
 [[package]]
 name = "powersync_core"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca826497b4096dc869569970712ad77c96108de46ad8237e671b61a937a47536"
+checksum = "32ab437bc28b8007e789d4d4b39861a7dbd1eca102d4c453f3ba12d320b0de7a"
 dependencies = [
  "bytes",
  "const_format",
@@ -3137,9 +3137,9 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite_nostd"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c81cb5ccc5d718ed7d304eb102198af2e5b6a707fed188dffed00f5efcee35"
+checksum = "f4e318c28daeba1a83f93eb42917972b243a5def587eb27a7c7e5da938df3b67"
 dependencies = [
  "bindgen",
  "num-derive 0.4.2",

--- a/powersync/Cargo.toml
+++ b/powersync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "powersync"
-version = "0.0.6"
+version = "0.0.7"
 
 edition = "2024"
 license = "Apache-2.0"
@@ -44,8 +44,8 @@ thiserror = "2.0.16"
 tokio = { version = "1", features = ["time", "rt"], optional = true }
 url = "2.5.7"
 serde_with = "3.15.0"
-powersync_core = { version = "=0.5.1", features = ["static"] }
-powersync_sqlite_nostd = { version = "=0.5.1", features = ["static"] }
+powersync_core = { version = "=0.5.2", features = ["static"] }
+powersync_sqlite_nostd = { version = "=0.5.2", features = ["static"] }
 num-traits = "0.2.19"
 
 [dev-dependencies]


### PR DESCRIPTION
This updates the PowerSync SQLite core extension to version 0.5.2, and prepares a release for the Rust crate.